### PR TITLE
Update Search.php to match baseclasses display() signature

### DIFF
--- a/lib/Page/Search.php
+++ b/lib/Page/Search.php
@@ -75,12 +75,12 @@ class Wicked_Page_Search extends Wicked_Page
     /**
      * Renders this page in display mode.
      *
-     * @param string $searchtext  The title to search for.
+     * @param string $searchtext  The title to search for (optional).
      *
      * @return string  The content.
      * @throws Wicked_Exception
      */
-    public function display($searchtext)
+    public function display($searchtext = null)
     {
         global $injector, $notification, $page_output, $wicked;
 


### PR DESCRIPTION
making the searchtext parameter optional, this derived classes display($searchtext) signature is comatible again with the base class.