### PR TITLE
Refactor renderChrome to use Horde buffer management

### DIFF
--- a/src/Controller/ResponseTrait.php
+++ b/src/Controller/ResponseTrait.php
@@ -35,13 +35,15 @@ trait ResponseTrait
 
     private function renderChrome(string $title, callable $renderBody): string
     {
-        ob_start();
+        // Use Horde's buffer tracking so PageOutput::header() doesn't call
+        // flush() in PSR-15 responses before ResponseWriterWeb writes headers.
+        \Horde::startBuffer();
         $this->pageOutput->header(['title' => $title]);
         $this->notification->notify(['listeners' => 'status']);
         $renderBody();
         $this->pageOutput->footer();
 
-        return ob_get_clean();
+        return \Horde::endBuffer();
     }
 
     protected function downloadResponse(


### PR DESCRIPTION
# Fix Wicked PSR header warnings caused by premature output flush
## Summary
- Fixes repeated `Cannot modify header information - headers already sent` warnings in Wicked after integrating search/topbar changes.
- Switches Wicked PSR controller chrome rendering from raw PHP buffering to Horde-managed buffering.

## Root Cause
Wicked PSR controllers used `ob_start()` / `ob_get_clean()` in the chrome render path.  
That bypassed Horde's internal buffer-state tracking used by `Horde::contentSent()`.  
During `PageOutput::header()`, this could trigger an early flush path, sending output before the PSR `ResponseWriterWeb` tried to emit headers.
## Changes
### `vendor/horde/wicked/src/Controller/ResponseTrait.php`
- Replaced:
  - `ob_start()` -> `\Horde::startBuffer()`
  - `ob_get_clean()` -> `\Horde::endBuffer()`

## Validation
- `php -l` passed for all modified files.
- Linter check passed for all modified files.
- Manual repro flow (Wicked root/search/page view) no longer produced repeated header warnings after applying the fix.
- 
## Risk / Compatibility
- Low risk: aligns buffering behavior with Horde internals.
- Compatible with maintained PHP 8.x versions.
- No dependency changes.
- No API/config/schema changes.