### PR TITLE
refactor(routes): replace Mapper with RoutesProvider

### DIFF
--- a/lib/Application.php
+++ b/lib/Application.php
@@ -28,7 +28,7 @@ if (!defined('HORDE_BASE')) {
 
 use Horde\Cache\Cache as HordeCache;
 use Horde\Cache\FileStorage;
-use Horde\Routes\Mapper;
+use Horde\Core\Uri\RoutesProvider;
 use Horde\Util\Variables;
 use Horde\Wicked\HordeWikilinkUrlResolver;
 use Horde\Wicked\Service\UrlGenerator;
@@ -97,15 +97,12 @@ class Wicked_Application extends Horde_Registry_Application
         $GLOBALS['injector']->bindClosure(
             UrlGenerator::class,
             function ($injector) {
-                $mapper = new Mapper();
-                require WICKED_BASE . '/config/routes.php';
-                if (file_exists(WICKED_BASE . '/config/routes.local.php')) {
-                    include WICKED_BASE . '/config/routes.local.php';
-                }
+                $provider = $injector->getInstance(RoutesProvider::class);
                 $registry = $injector->getInstance('Horde_Registry');
                 $webroot = $registry->get('webroot', 'wicked');
+                $runtimeProvider = $injector->getInstance(\Horde\Core\RuntimeRoutesProvider::class);
 
-                return new UrlGenerator($mapper, $webroot);
+                return new UrlGenerator($provider, $webroot, $runtimeProvider->environ);
             },
         );
     }

--- a/src/Service/UrlGenerator.php
+++ b/src/Service/UrlGenerator.php
@@ -11,43 +11,31 @@ declare(strict_types=1);
 
 namespace Horde\Wicked\Service;
 
-use Horde\Routes\Mapper;
-use Horde\Routes\Utils;
+use Horde\Core\Uri\RoutesProvider;
 
 /**
- * Injectable URL generator wrapping Horde\Routes\Utils.
+ * Injectable URL generator wrapping RoutesProvider.
  *
- * Provides named-route URL generation for Wicked controllers, replacing
- * static Wicked::url() calls.
+ * Provides named-route URL generation for Wicked controllers.
  *
  * @category Horde
  * @license  http://www.horde.org/licenses/gpl GPL
  * @package  Wicked
  */
-/**
- * NOTE: New code should use Horde\Core\Uri\RouteUrlWriter instead.
- * RouteUrlWriter consumes the RoutesProvider interface and works in both
- * Rampage (without legacy bootstrap) and legacy flows. This class remains
- * for existing callers wired through _bootstrap() in Application.php.
- */
 class UrlGenerator
 {
-    private Utils $utils;
-
     public function __construct(
-        private readonly Mapper $mapper,
+        private readonly RoutesProvider $provider,
         private readonly string $webroot,
-    ) {
-        $this->mapper->environ['SCRIPT_NAME'] = rtrim($webroot, '/');
-        $this->utils = new Utils($this->mapper);
-    }
+        private readonly array $environ = [],
+    ) {}
 
     /**
      * Generate a relative URL for a named route.
      */
     public function urlFor(string $routeName, array $params = []): string
     {
-        return $this->utils->urlFor($routeName, $params);
+        return $this->provider->generateNamedPath($routeName, $params) ?? '';
     }
 
     /**
@@ -55,8 +43,19 @@ class UrlGenerator
      */
     public function absoluteUrlFor(string $routeName, array $params = []): string
     {
-        $params['qualified'] = true;
+        $path = $this->provider->generateNamedPath($routeName, $params);
+        if ($path === null) {
+            return '';
+        }
 
-        return $this->utils->urlFor($routeName, $params);
+        $host = $this->environ['HTTP_HOST']
+            ?? $this->environ['SERVER_NAME']
+            ?? 'localhost';
+
+        $scheme = (!empty($this->environ['HTTPS']) && $this->environ['HTTPS'] !== 'off')
+            ? 'https'
+            : 'http';
+
+        return $scheme . '://' . $host . $path;
     }
 }


### PR DESCRIPTION
## Summary
- Migrate `UrlGenerator` from legacy `Mapper` to `RoutesProvider` interface
- Factory resolves `RoutesProvider` + `RuntimeRoutesProvider` for environ

## Test plan
- [ ] Verify wiki page links generate correctly
- [ ] No TypeError on page load