### PR TITLE
refactor: Use a data attribute for preview route

### DIFF
--- a/js/edit.js
+++ b/js/edit.js
@@ -1,17 +1,22 @@
 var WickedEdit = {
-    loadPreview: function()
-    {
-        var f = document.getElementById('wicked-edit'), oldAction = f.action;
+    loadPreview: function () {
+        var f = document.getElementById('wicked-edit'),
+            btn = document.getElementById('wicked-preview'),
+            oldAction = f.action,
+            previewUrl = btn && btn.dataset.previewUrl;
 
-        f.action = 'preview.php';
+        if (!previewUrl) {
+            return;
+        }
+
+        f.action = previewUrl;
         f.target = '_blank';
         f.submit();
         f.action = oldAction;
         f.target = '';
     },
 
-    onDomLoad: function()
-    {
+    onDomLoad: function () {
         var btn = document.getElementById('wicked-preview');
         if (btn) {
             btn.addEventListener('click', this.loadPreview);

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -100,7 +100,7 @@ class Wicked_Application extends Horde_Registry_Application
                 $provider = $injector->getInstance(RoutesProvider::class);
                 $registry = $injector->getInstance('Horde_Registry');
                 $webroot = $registry->get('webroot', 'wicked');
-                $runtimeProvider = $injector->getInstance(\Horde\Core\RuntimeRoutesProvider::class);
+                $runtimeProvider = $injector->getInstance(Horde\Core\RuntimeRoutesProvider::class);
 
                 return new UrlGenerator($provider, $webroot, $runtimeProvider->environ);
             },

--- a/lib/Factory/Driver.php
+++ b/lib/Factory/Driver.php
@@ -1,4 +1,5 @@
 <?php
+
 use Horde\Injector\Injector;
 
 /**

--- a/lib/Page.php
+++ b/lib/Page.php
@@ -13,7 +13,6 @@
  */
 use Horde\Wicked\WickedEngine;
 use Horde\Util\Util;
-
 use Horde\Date\Format;
 
 /**

--- a/lib/Page/AttachedFiles.php
+++ b/lib/Page/AttachedFiles.php
@@ -13,7 +13,6 @@
  * @package  Wicked
  */
 use Horde\Util\Util;
-
 use Horde\Date\Format;
 
 /**
@@ -238,7 +237,7 @@ class Wicked_Page_AttachedFiles extends Wicked_Page
              * WARNING: Horde_Util::dispelMagicQuotes() removed in PSR-4 version
              * Magic quotes are obsolete in PHP 8+. Remove this call.
              */
-$filename = Horde_Util::dispelMagicQuotes($_FILES['attachment_file']['name']);
+            $filename = Horde_Util::dispelMagicQuotes($_FILES['attachment_file']['name']);
         }
 
         try {

--- a/lib/Page/DeletePage.php
+++ b/lib/Page/DeletePage.php
@@ -112,7 +112,7 @@ class Wicked_Page_DeletePage extends Wicked_Page
              * @deprecated Use Horde_Themes_Image::tag() instead
              * @see Horde_Deprecated::img()
              */
-echo Horde::img('locked.png', _("Locked"));
+            echo Horde::img('locked.png', _("Locked"));
         } ?>
 </h1>
 

--- a/lib/Page/EditPage.php
+++ b/lib/Page/EditPage.php
@@ -127,6 +127,9 @@ class Wicked_Page_EditPage extends Wicked_Page
 
         $view = $GLOBALS['injector']->createInstance('Horde_View');
         $view->action = Wicked::url('EditPage');
+        $view->previewAction = $GLOBALS['injector']
+            ->getInstance(Horde\Core\Uri\RouteUrlWriter::class)
+            ->urlFor('Preview');
         $view->formInput = Util::formInput();
         $view->name = $page->pageName();
         $view->header = $page->pageUrl()->link()

--- a/lib/Page/RevertPage.php
+++ b/lib/Page/RevertPage.php
@@ -101,7 +101,7 @@ class Wicked_Page_RevertPage extends Wicked_Page
              * @deprecated Use Horde_Themes_Image::tag() instead
              * @see Horde_Deprecated::img()
              */
-echo Horde::img('locked.png', _("Locked"));
+            echo Horde::img('locked.png', _("Locked"));
         } ?>
 </h1>
 

--- a/src/Controller/ResponseTrait.php
+++ b/src/Controller/ResponseTrait.php
@@ -16,6 +16,7 @@ use Horde\Horde\Traits\RedirectResponseTrait;
 use Horde\Http\Response;
 use Horde\Http\StreamFactory;
 use Psr\Http\Message\ResponseInterface;
+use Horde;
 
 /**
  * Shared response helpers for Wicked PSR-15 controllers.
@@ -37,13 +38,13 @@ trait ResponseTrait
     {
         // Use Horde's buffer tracking so PageOutput::header() doesn't call
         // flush() in PSR-15 responses before ResponseWriterWeb writes headers.
-        \Horde::startBuffer();
+        Horde::startBuffer();
         $this->pageOutput->header(['title' => $title]);
         $this->notification->notify(['listeners' => 'status']);
         $renderBody();
         $this->pageOutput->footer();
 
-        return \Horde::endBuffer();
+        return Horde::endBuffer();
     }
 
     protected function downloadResponse(

--- a/src/WickedEngine.php
+++ b/src/WickedEngine.php
@@ -30,6 +30,7 @@ use Horde_Url;
 use Psr\SimpleCache\CacheInterface;
 use Throwable;
 use Wicked_Driver;
+use SplObjectStorage;
 
 /**
  * Wicked wiki engine — new-style AST-based implementation
@@ -330,7 +331,7 @@ class WickedEngine implements WikiEngine
         }, $document, DocumentNode::class);
         $clearChildren();
 
-        $replaceMap = new \SplObjectStorage();
+        $replaceMap = new SplObjectStorage();
         foreach ($replacements as $r) {
             $replaceMap[$r['old']] = $r['new'];
         }

--- a/templates/edit/new.html.php
+++ b/templates/edit/new.html.php
@@ -22,7 +22,7 @@
 
 <div class="horde-form-buttons">
  <input type="submit" value="<?php echo _("Save") ?>" class="horde-default" />
- <input type="button" id="wicked-preview" value="<?php echo _("Preview") ?>" />
+ <input type="button" id="wicked-preview" data-preview-url="<?php echo htmlspecialchars((string) $this->previewAction) ?>" value="<?php echo _("Preview") ?>" />
 </div>
 
 </form>

--- a/templates/edit/standard.html.php
+++ b/templates/edit/standard.html.php
@@ -27,7 +27,7 @@
 
 <div class="horde-form-buttons">
  <input type="submit" value="<?php echo _("Save") ?>" class="horde-default" />
- <input type="button" id="wicked-preview" value="<?php echo _("Preview") ?>" />
+ <input type="button" id="wicked-preview" data-preview-url="<?php echo htmlspecialchars((string) $this->previewAction) ?>" value="<?php echo _("Preview") ?>" />
  <?php echo $this->cancel ?>
 </div>
 


### PR DESCRIPTION
Wicked preview button used a relative URL and worked depending on where in the wiki hierarchy a page was anchored.